### PR TITLE
Revert card color changes for better readability and background location

### DIFF
--- a/themes/waves.yaml
+++ b/themes/waves.yaml
@@ -15,7 +15,7 @@ waves-dark:
   # Change the value below 6px to 0px to remove the rounded corners
   ha-card-border-radius: 6px
   # Place the backgrounds in the folder  config/www/images/backgrounds 
-  lovelace-background: 'center / cover no-repeat url("/hacsfiles/themes/waves-dev/files/background.png") fixed'
+  lovelace-background: 'center / cover no-repeat url("/hacsfiles/themes/waves/background.png") fixed'
   # Main colors
   primary-color: rgba(41, 128, 185, 1.0)
   secondary-color: "#283E54"

--- a/themes/waves.yaml
+++ b/themes/waves.yaml
@@ -70,8 +70,7 @@ waves-dark:
   label-badge-red: var(--primary-color)
   label-badge-blue: var(--light-primary-color)
   # Cards colors
-  ha-card-background: rgba(34, 53, 72, 0.55)
-  card-background-color: var(--secondary-background-color)
+  ha-card-background: rgba(100, 100, 100, 0.15)
   paper-card-background-color: var(--ha-card-background)
   paper-listbox-background-color: var(--primary-background-color)
   # Toggle button colors

--- a/themes/waves.yaml
+++ b/themes/waves.yaml
@@ -138,7 +138,7 @@ waves-light:
   # Change the value below 6px to 0px to remove the rounded corners
   ha-card-border-radius: 6px
   # Place the backgrounds in the folder  config/www/images/backgrounds 
-  lovelace-background: 'center / cover no-repeat url("/hacsfiles/themes/waves-dev/files/background-light.png") fixed'
+  lovelace-background: 'center / cover no-repeat url("/hacsfiles/themes/waves/background-light.png") fixed'
   # Main colors
   primary-color: rgba(41, 128, 185, 1)
   secondary-color: rgba(52, 152, 219, 1)


### PR DESCRIPTION
Cards having a slightly different background makes dashboards readability better when there are multiple cards on a dashboard.

Pre changes
![afbeelding](https://user-images.githubusercontent.com/48241736/130749765-2b654fdf-c7a5-4e91-a482-399d59832910.png)

Post changes
![afbeelding](https://user-images.githubusercontent.com/48241736/130749522-0a5cf9d8-1ec1-4836-be79-9b300456ddbd.png)

Background URL still had the dev location.