### PR TITLE
Fix for 2023.3 and higher light card.

### DIFF
--- a/themes/waves.yaml
+++ b/themes/waves.yaml
@@ -64,6 +64,8 @@ waves:
       state-light-on-color: var(--primary-color)
       state-remote-on-color: var(--primary-color)
       state-switch-on-color: var(--primary-color)
+      # Fix for 2023.03 and higher.
+      state-light-active-color: var(--primary-color)
       # Settins and colors of Mini Media Player
       mini-media-player-icon-color: var(--primary-color)
       mini-media-player-accent-color: var(--primary-color)
@@ -207,6 +209,8 @@ waves:
       state-light-on-color: var(--primary-color)
       state-remote-on-color: var(--primary-color)
       state-switch-on-color: var(--primary-color)
+      # Fix for 2023.03 and higher.
+      state-light-active-color: var(--primary-color)
       # Settins and colors of Mini Media Player
       mini-media-player-icon-color: var(--primary-color)
       mini-media-player-accent-color: var(--primary-color)


### PR DESCRIPTION
Hopefully this is the end of the fixes for a while. Fix for the most recent version of Home Assistant 2023.3 with the updated light card.